### PR TITLE
Add voluntary payment popup for watermark removal

### DIFF
--- a/preview.html
+++ b/preview.html
@@ -896,6 +896,101 @@
         opacity: 1;
         transform: scale(1);
       }
+
+      /* Support Modal Styling */
+      .support-modal {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 10000;
+        opacity: 0;
+        visibility: hidden;
+        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+      }
+      .support-modal.active {
+        opacity: 1;
+        visibility: visible;
+      }
+      .support-modal.closing {
+        opacity: 0;
+        visibility: hidden;
+      }
+      .support-backdrop {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.7);
+        backdrop-filter: blur(10px);
+      }
+      .support-container {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%) scale(0.9);
+        background: rgba(255, 255, 255, 0.98);
+        backdrop-filter: blur(20px);
+        border-radius: 20px;
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+        width: 90%;
+        max-width: 520px;
+        overflow: hidden;
+        transition: transform 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+      }
+      .support-modal.active .support-container {
+        transform: translate(-50%, -50%) scale(1);
+      }
+      .support-modal.closing .support-container {
+        transform: translate(-50%, -50%) scale(0.9);
+      }
+      .support-header {
+        padding: 18px 22px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background: linear-gradient(135deg, #72a4f2 0%, #7ed8f7 100%);
+        color: #fff;
+      }
+      .support-header h3 {
+        margin: 0;
+        font-size: 18px;
+        font-weight: 700;
+      }
+      .support-content {
+        padding: 20px 22px 26px;
+        text-align: center;
+      }
+      .support-message {
+        margin: 10px 0 18px;
+        color: #333;
+        font-size: 15px;
+        line-height: 1.5;
+        font-weight: 500;
+      }
+      .support-cta-btn {
+        display: inline-block;
+        padding: 12px 18px;
+        background: #72a4f2;
+        color: #fff;
+        border-radius: 10px;
+        text-decoration: none;
+        font-weight: 700;
+        box-shadow: 0 8px 20px rgba(114, 164, 242, 0.35);
+        transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+      }
+      .support-cta-btn:hover {
+        transform: translateY(-1px);
+        background: #6497ee;
+        box-shadow: 0 10px 24px rgba(114, 164, 242, 0.45);
+      }
+      .support-note {
+        margin-top: 12px;
+        font-size: 12px;
+        color: #666;
+      }
     </style>
   </head>
   <body>

--- a/preview.js
+++ b/preview.js
@@ -266,7 +266,68 @@ document.addEventListener("DOMContentLoaded", () => {
     }, 3000);
   }
   
-    /**
+  /**
+   * Show support modal and proceed with watermark removal
+   */
+  function handleRemoveWatermarkClick() {
+    if (!watermarkRemoved) {
+      const modal = createSupportModal();
+      document.body.appendChild(modal);
+      setTimeout(() => {
+        modal.classList.add('active');
+      }, 10);
+    }
+    removeWatermark();
+  }
+  
+  /**
+   * Create support modal asking for voluntary contribution
+   */
+  function createSupportModal() {
+    const modal = document.createElement('div');
+    modal.className = 'support-modal';
+    modal.innerHTML = `
+      <div class="support-backdrop"></div>
+      <div class="support-container">
+        <div class="support-header">
+          <h3>💛 Support Quotura</h3>
+          <button class="close-btn">✕</button>
+        </div>
+        <div class="support-content">
+          <p class="support-message">“Enjoying Quotura? Your support helps keep it fast, simple, and free! If you’d like, you can make a voluntary contribution. Every little bit helps!”</p>
+          <a href="https://ko-fi.com/W7W61JP2OR" target="_blank" rel="noopener" class="support-cta-btn">You're Awesome</a>
+          <div class="support-note">No pressure — you can still remove the watermark even if you don’t pay.</div>
+        </div>
+      </div>
+    `;
+
+    const closeBtn = modal.querySelector('.close-btn');
+    const backdrop = modal.querySelector('.support-backdrop');
+    const ctaBtn = modal.querySelector('.support-cta-btn');
+
+    const close = () => closeSupportModal(modal);
+    closeBtn.addEventListener('click', close);
+    backdrop.addEventListener('click', close);
+    ctaBtn.addEventListener('click', () => {
+      setTimeout(() => closeSupportModal(modal), 100);
+    });
+
+    return modal;
+  }
+  
+  /**
+   * Close support modal with animation
+   */
+  function closeSupportModal(modal) {
+    modal.classList.add('closing');
+    setTimeout(() => {
+      if (modal && modal.parentNode) {
+        document.body.removeChild(modal);
+      }
+    }, 300);
+  }
+  
+  /**
    * Handle Quick Edit button click - shows edit panel
    */
   function handleQuickEdit() {
@@ -457,7 +518,7 @@ document.addEventListener("DOMContentLoaded", () => {
   downloadPngBtn.addEventListener("click", downloadPNG);
   downloadSvgBtn.addEventListener("click", downloadSVG);
   copyImageBtn.addEventListener("click", copyToClipboard);
-  removeWatermarkBtn.addEventListener("click", removeWatermark);
+  removeWatermarkBtn.addEventListener("click", handleRemoveWatermarkClick);
   
   // Event listener for quick edit
   quickEditBtn.addEventListener("click", handleQuickEdit);


### PR DESCRIPTION
Add a voluntary support popup when 'Remove Watermark' is clicked, allowing users to contribute while still removing the watermark.

A custom modal was implemented instead of the provided Ko-fi widget snippet due to Chrome extension Content Security Policy (CSP) restrictions on remote inline scripts.

---
<a href="https://cursor.com/background-agent?bcId=bc-98142c20-2a69-44d4-83b0-d05464f4026d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-98142c20-2a69-44d4-83b0-d05464f4026d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

