### PR TITLE
Fix quick edit ui and button states

### DIFF
--- a/preview.html
+++ b/preview.html
@@ -534,15 +534,15 @@
       }
       
       /* Staggered animation for buttons */
-      .edit-panel.active .panel-btn:nth-child(1) {
+      .edit-panel.active button.panel-btn:nth-of-type(1) {
         animation: slideInPanel 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55) 0.1s forwards;
       }
       
-      .edit-panel.active .panel-btn:nth-child(2) {
+      .edit-panel.active button.panel-btn:nth-of-type(2) {
         animation: slideInPanel 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55) 0.2s forwards;
       }
       
-      .edit-panel.active .panel-btn:nth-child(3) {
+      .edit-panel.active button.panel-btn:nth-of-type(3) {
         animation: slideInPanel 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55) 0.3s forwards;
       }
       

--- a/preview.js
+++ b/preview.js
@@ -80,7 +80,12 @@ document.addEventListener("DOMContentLoaded", () => {
     downloadPngBtn.disabled = false;
     downloadSvgBtn.disabled = false;
     copyImageBtn.disabled = false;
-    removeWatermarkBtn.disabled = false;
+    removeWatermarkBtn.disabled = watermarkRemoved;
+    if (watermarkRemoved) {
+      removeWatermarkBtn.textContent = "✅ Watermark Removed";
+      removeWatermarkBtn.classList.remove("btn-warning");
+      removeWatermarkBtn.classList.add("btn-success");
+    }
   }
   
   /**


### PR DESCRIPTION
Fixes Quick Edit "Done" button visibility and disables "Remove Watermark" button after use.

The "Done" button in Quick Edit was not animating into view because the CSS `nth-child` selectors were incorrectly targeting elements. This PR updates the selectors to `nth-of-type` to correctly target the button elements. Additionally, the "Remove Watermark" button now correctly disables and shows a success state after being clicked, preventing multiple removals and providing clear feedback.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad25c7a5-79b4-4d56-8326-b148d716d3c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ad25c7a5-79b4-4d56-8326-b148d716d3c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

