### PR TITLE
Remove extra done button below quick edit

### DIFF
--- a/preview.html
+++ b/preview.html
@@ -575,16 +575,7 @@
         box-shadow: 0 5px 15px rgba(67, 233, 123, 0.4);
       }
       
-      /* Secondary Done button at the end of quick edit container */
-      .quick-edit-container #doneBtnEnd {
-        display: none;
-        transform: none;
-        opacity: 1;
-      }
       
-      .quick-edit-container .edit-panel.active ~ #doneBtnEnd {
-        display: inline-flex;
-      }
       
       /* Button icons */
       .btn-icon {
@@ -1172,10 +1163,6 @@
           <span class="btn-text">Done</span>
         </button>
       </div>
-      <button id="doneBtnEnd" class="panel-btn done-btn">
-        <span class="btn-icon">✅</span>
-        <span class="btn-text">Done</span>
-      </button>
     </div>
     
     <!-- Container for the generated quote image -->

--- a/preview.js
+++ b/preview.js
@@ -15,7 +15,6 @@ document.addEventListener("DOMContentLoaded", () => {
   const increaseSizeBtn = document.getElementById("increaseSizeBtn");       // Increase size button
   const currentSizeDisplay = document.getElementById("currentSize");        // Current size display
   const doneBtn = document.getElementById("doneBtn");                       // Done button
-  const doneBtnEnd = document.getElementById("doneBtnEnd");                 // Secondary Done button at end
   const backgroundBtn = document.getElementById("backgroundBtn");           // Background selection button
   
   // State variables
@@ -638,7 +637,6 @@ document.addEventListener("DOMContentLoaded", () => {
   decreaseSizeBtn.addEventListener("click", () => handleSizeChange(-2));
   increaseSizeBtn.addEventListener("click", () => handleSizeChange(2));
   doneBtn.addEventListener("click", handleDone);
-  doneBtnEnd.addEventListener("click", handleDone);
   
   // Interactive blob functionality
   initializeInteractiveBlobs();


### PR DESCRIPTION
Remove duplicate 'Done' button displayed below Quick Edit.

---
<a href="https://cursor.com/background-agent?bcId=bc-104447be-9f63-4279-ae21-b4f43497ba09">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-104447be-9f63-4279-ae21-b4f43497ba09">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

