### PR TITLE
Add direct text editing to quick edit

### DIFF
--- a/preview.html
+++ b/preview.html
@@ -1146,6 +1146,10 @@
           <span class="btn-icon">🎨</span>
           <span class="btn-text">Background</span>
         </button>
+        <button id="editTextBtn" class="panel-btn">
+          <span class="btn-icon">📝</span>
+          <span class="btn-text">Edit Text</span>
+        </button>
         <div id="fontSizeContainer" class="size-container">
           <button id="decreaseSizeBtn" class="size-btn decrease-btn">
             <span class="size-icon">−</span>


### PR DESCRIPTION
Add an "Edit Text" option to Quick Edit to allow direct modification of the image's text content with live preview updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-493931c2-b03a-404e-8f27-2663f4772229">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-493931c2-b03a-404e-8f27-2663f4772229">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

