### PR TITLE
Show done button on quick edit

### DIFF
--- a/preview.html
+++ b/preview.html
@@ -546,6 +546,10 @@
         animation: slideInPanel 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55) 0.3s forwards;
       }
       
+      .edit-panel.active button.panel-btn:nth-of-type(4) {
+        animation: slideInPanel 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55) 0.4s forwards;
+      }
+      
       @keyframes slideInPanel {
         to {
           transform: translateX(0);


### PR DESCRIPTION
Add CSS rule to animate the 'Done' button into view when Quick Edit is active.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd826dcd-1f41-4552-96bd-dfbc8627e3af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cd826dcd-1f41-4552-96bd-dfbc8627e3af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

