### PR TITLE
Enable direct in-image text editing

### DIFF
--- a/preview.html
+++ b/preview.html
@@ -291,6 +291,39 @@
           0 0 80px rgba(255, 255, 255, 0.2);
       }
       
+      /* Image container for inline editor overlay */
+      #imageContainer {
+        position: relative;
+        display: inline-block;
+      }
+
+      /* Inline text editor positioned over the image */
+      #inlineEditor {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: 85%;
+        max-width: 85%;
+        color: #ffffff;
+        text-align: center;
+        font-weight: bold;
+        line-height: 1.3;
+        outline: none;
+        border: none;
+        padding: 0 10px;
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        text-shadow: 0 1px 2px rgba(0,0,0,0.3);
+        display: none;
+        z-index: 5;
+        cursor: text;
+      }
+
+      #inlineEditor.active {
+        display: block;
+      }
+      
       /* Export buttons container with glassmorphism */
       .export-buttons {
         margin-top: 30px;
@@ -1174,7 +1207,10 @@
     </div>
     
     <!-- Container for the generated quote image -->
-    <img id="image" src="" alt="Beautified Quote" />
+    <div id="imageContainer">
+      <img id="image" src="" alt="Beautified Quote" />
+      <div id="inlineEditor" contenteditable="true" aria-label="Edit quote text"></div>
+    </div>
     
     <!-- Export buttons for various download options -->
     <div class="export-buttons">


### PR DESCRIPTION
Enable inline text editing directly on the image, triggered by image click or the "Edit Text" button, replacing the previous popup editor.

---
<a href="https://cursor.com/background-agent?bcId=bc-378f4553-37b8-4cae-8f71-8b8cc03e0f2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-378f4553-37b8-4cae-8f71-8b8cc03e0f2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

