### PR TITLE
Center the preview image

### DIFF
--- a/preview.html
+++ b/preview.html
@@ -294,7 +294,10 @@
       /* Image container for inline editor overlay */
       #imageContainer {
         position: relative;
-        display: inline-block;
+        display: block;
+        width: max-content;
+        margin-left: auto;
+        margin-right: auto;
       }
 
       /* Inline text editor positioned over the image */


### PR DESCRIPTION
Center the preview image by adjusting the image container's CSS.

---
<a href="https://cursor.com/background-agent?bcId=bc-b7935d9a-f259-4b82-a5e5-0ea93b052473">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b7935d9a-f259-4b82-a5e5-0ea93b052473">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

