### PR TITLE
Add inline done button on image click

### DIFF
--- a/preview.html
+++ b/preview.html
@@ -326,6 +326,16 @@
       #inlineEditor.active {
         display: block;
       }
+     
+      /* Inline done button container */
+      .inline-done-container {
+        margin-top: 12px;
+        display: none;
+      }
+      
+      .inline-done-btn {
+        min-width: 150px;
+      }
       
       /* Export buttons container with glassmorphism */
       .export-buttons {
@@ -1214,6 +1224,10 @@
       <img id="image" src="" alt="Beautified Quote" />
       <div id="inlineEditor" contenteditable="true" aria-label="Edit quote text"></div>
     </div>
+   
+   <div id="inlineDoneContainer" class="inline-done-container">
+     <button id="inlineDoneBtn" class="export-btn btn-success inline-done-btn">✅ Done</button>
+   </div>
     
     <!-- Export buttons for various download options -->
     <div class="export-buttons">

--- a/preview.js
+++ b/preview.js
@@ -18,6 +18,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const backgroundBtn = document.getElementById("backgroundBtn");           // Background selection button
   const editTextBtn = document.getElementById("editTextBtn");               // Edit text button
   const inlineEditor = document.getElementById("inlineEditor");             // Inline editor overlay
+  const inlineDoneContainer = document.getElementById("inlineDoneContainer"); // Inline Done container
+  const inlineDoneBtn = document.getElementById("inlineDoneBtn");             // Inline Done button
   
   // State variables
   let currentImageData = null;
@@ -446,6 +448,7 @@ document.addEventListener("DOMContentLoaded", () => {
       syncInlineEditorStyles();
       inlineEditing = true;
       inlineEditor.classList.add('active');
+      if (inlineDoneContainer) inlineDoneContainer.style.display = 'block';
       setTimeout(() => {
         inlineEditor.focus();
         placeCaretAtEnd(inlineEditor);
@@ -457,6 +460,7 @@ document.addEventListener("DOMContentLoaded", () => {
     inlineEditing = false;
     inlineEditor.classList.remove('active');
     inlineEditor.blur();
+    if (inlineDoneContainer) inlineDoneContainer.style.display = 'none';
   }
   
   /**
@@ -761,6 +765,7 @@ document.addEventListener("DOMContentLoaded", () => {
   increaseSizeBtn.addEventListener("click", () => handleSizeChange(2));
   doneBtn.addEventListener("click", handleDone);
   editTextBtn.addEventListener("click", handleEditText);
+  if (inlineDoneBtn) inlineDoneBtn.addEventListener('click', handleDone);
   
   // Open inline editor when image is clicked
   img.addEventListener("click", openInlineEditor);


### PR DESCRIPTION
Add an inline "Done" button below the image to close the inline editor directly.

---
<a href="https://cursor.com/background-agent?bcId=bc-af838017-d177-4690-8b6d-bd44b63baea3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af838017-d177-4690-8b6d-bd44b63baea3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

