### PR TITLE
Center the preview image

### DIFF
--- a/preview.html
+++ b/preview.html
@@ -295,12 +295,12 @@
       /* Image container for inline editor overlay */
       #imageContainer {
         position: relative;
-        display: block;
-        width: fit-content;
-        margin-left: auto;
-        margin-right: auto;
+        display: flex;
+        width: 100%;
+        justify-content: center;
+        align-items: center;
       }
-
+      
       /* Inline text editor positioned over the image */
       #inlineEditor {
         position: absolute;
@@ -323,7 +323,7 @@
         z-index: 5;
         cursor: text;
       }
-
+      
       #inlineEditor.active {
         display: block;
       }


### PR DESCRIPTION
Center the preview image by updating `#imageContainer` to use a full-width flex container with `justify-content: center` and `align-items: center`.

---
<a href="https://cursor.com/background-agent?bcId=bc-d18df08c-75cf-470a-8d46-c9d979f53495">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d18df08c-75cf-470a-8d46-c9d979f53495">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

