### PR TITLE
Fix quick edit buttons not working

### DIFF
--- a/preview.html
+++ b/preview.html
@@ -448,6 +448,7 @@
         margin: 20px 0;
         text-align: center;
         position: relative;
+        z-index: 9999;
       }
       
       .quick-edit-btn {


### PR DESCRIPTION
Add `z-index` to `.quick-edit-container` to make quick edit buttons clickable.

The quick edit buttons (font, size, textedit, background) were not clickable because the quick edit container was rendered underneath other elements, preventing pointer events. Raising its `z-index` ensures it sits above other content and its buttons are interactive.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f001106-4885-4991-a0ac-0a3b60399283">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3f001106-4885-4991-a0ac-0a3b60399283">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

