### PR TITLE
Fix image preview background size on edit click

### DIFF
--- a/preview.js
+++ b/preview.js
@@ -65,7 +65,31 @@
     }
   }
 
+  // Ensure edit overlays match the rendered image size exactly
+  function syncEditOverlayToImage() {
+    try {
+      if (!img || !editBackground || !inlineEditor) return;
+      const imageWidth = img.clientWidth;
+      const imageHeight = img.clientHeight;
+      if (!imageWidth || !imageHeight) return;
+      // Match background size to image
+      editBackground.style.width = `${imageWidth}px`;
+      editBackground.style.height = `${imageHeight}px`;
+      // Keep editor width aligned with image for consistent typing area
+      inlineEditor.style.width = `${imageWidth}px`;
+      inlineEditor.style.maxWidth = `${imageWidth}px`;
+    } catch (_) {}
+  }
+
+  // Keep overlays in sync with image dimensions on load and resize
+  if (img) {
+    img.addEventListener('load', syncEditOverlayToImage, { once: false });
+  }
+  window.addEventListener('resize', syncEditOverlayToImage, { passive: true });
+
   function showEditingVisuals() {
+    // Ensure overlay matches current image size before showing
+    syncEditOverlayToImage();
     if (editBackground) editBackground.classList.add('active');
     if (img) img.style.visibility = 'hidden';
     updateEditBackgroundGradient();


### PR DESCRIPTION
Fix: Make the image preview background the same size as the image when clicking "Edit text".

Previously, the edit background overlay would expand beyond the image's dimensions. This change ensures the `#editBackground` and `#inlineEditor` elements precisely match the rendered image's width and height on image load, window resize, and when entering edit mode, preventing the background from overflowing.

---
<a href="https://cursor.com/background-agent?bcId=bc-f8ecdd6f-b81f-486c-bf21-23390d3f17bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f8ecdd6f-b81f-486c-bf21-23390d3f17bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

