### PR TITLE
Handle new line on enter key

### DIFF
--- a/background.js
+++ b/background.js
@@ -128,36 +128,43 @@ function generateSVGQuote(text, gradient, includeWatermark = true) {
 }
 
 /**
- * Text wrapping algorithm for canvas rendering
- * Breaks text into lines that fit within specified width constraints
+ * Text wrapping algorithm for canvas/SVG rendering
+ * Preserves user-inserted newlines and wraps each paragraph to the given width
  * @param {CanvasRenderingContext2D} ctx - Canvas context for text measurement
- * @param {string} text - Text to wrap
+ * @param {string} text - Text to wrap (may include \n)
  * @param {number} maxWidth - Maximum width in pixels for each line
- * @returns {string[]} Array of text lines that fit within maxWidth
+ * @returns {string[]} Array of text lines that fit within maxWidth, preserving blank lines
  */
 function wrapText(ctx, text, maxWidth) {
-  const words = text.split(" ");
-  let line = "";
-  const lines = [];
-  
-  // Process each word and build lines
-  for (let n = 0; n < words.length; n++) {
-    const testLine = line + words[n] + " ";
-    
-    // Check if adding this word exceeds maxWidth
-    if (ctx.measureText(testLine).width > maxWidth && n > 0) {
-      // Current line is full, save it and start new line
-      lines.push(line.trim());
-      line = words[n] + " ";
-    } else {
-      // Word fits, add it to current line
-      line = testLine;
+  const allLines = [];
+  const paragraphs = String(text).split(/\r?\n/);
+
+  paragraphs.forEach((paragraph) => {
+    // Preserve intentional blank lines
+    if (paragraph.length === 0) {
+      allLines.push("");
+      return;
     }
-  }
-  
-  // Add the final line
-  lines.push(line.trim());
-  return lines;
+
+    const words = paragraph.split(/\s+/);
+    let currentLine = "";
+
+    for (let i = 0; i < words.length; i++) {
+      const word = words[i];
+      const testLine = currentLine ? currentLine + " " + word : word;
+
+      if (ctx.measureText(testLine).width > maxWidth && currentLine) {
+        allLines.push(currentLine);
+        currentLine = word;
+      } else {
+        currentLine = testLine;
+      }
+    }
+
+    allLines.push(currentLine);
+  });
+
+  return allLines;
 }
 
 /**


### PR DESCRIPTION
Preserve user-inserted newlines in generated images and SVGs by updating the `wrapText` function.

The inline editor correctly displayed newlines, but the `wrapText` function used for rendering the final image/SVG did not account for `\n` characters, causing them to be lost. This change modifies `wrapText` to split the input text into paragraphs based on newlines and then wraps each paragraph independently, ensuring visual consistency between the editor and the output.

---
<a href="https://cursor.com/background-agent?bcId=bc-1045c398-5f1e-43f2-8ff3-f473575376bf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1045c398-5f1e-43f2-8ff3-f473575376bf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

