### PR TITLE
Handle text input and save changes

### DIFF
--- a/preview.js
+++ b/preview.js
@@ -855,6 +855,15 @@
    * Handle Done button click - hides edit panel
    */
   function handleDone() {
+    // If inline editor is open, persist the latest text (including newlines)
+    // and trigger a final regenerate before closing the editor
+    if (inlineEditing && inlineEditor) {
+      const finalText = inlineEditor.textContent || "";
+      currentText = finalText;
+      if (isChromeAvailable()) chrome.storage.local.set({ quoteText: finalText });
+      regenerateWithSettingsUsingText(finalText);
+    }
+
     if (editMode) {
       // Exit edit mode with animation
       editPanel.classList.add("exiting");


### PR DESCRIPTION
Persist inline editor text, including newlines, when "Done" is clicked to save multi-line edits.

---
<a href="https://cursor.com/background-agent?bcId=bc-3602c0a5-5d68-49b1-89a8-54a5af9e9b40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3602c0a5-5d68-49b1-89a8-54a5af9e9b40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

