### PR TITLE
Fix newline preservation on text edit done

### DIFF
--- a/preview.js
+++ b/preview.js
@@ -858,7 +858,7 @@
     // If inline editor is open, persist the latest text (including newlines)
     // and trigger a final regenerate before closing the editor
     if (inlineEditing && inlineEditor) {
-      const finalText = inlineEditor.textContent || "";
+      const finalText = (inlineEditor.innerText || "").replace(/\r\n/g, '\n');
       currentText = finalText;
       if (isChromeAvailable()) chrome.storage.local.set({ quoteText: finalText });
       regenerateWithSettingsUsingText(finalText);
@@ -904,7 +904,7 @@
   
   // Inline editor live update
   inlineEditor.addEventListener('input', () => {
-    const newText = inlineEditor.textContent || '';
+    const newText = (inlineEditor.innerText || '').replace(/\r\n/g, '\n');
     currentText = newText;
     if (isChromeAvailable()) chrome.storage.local.set({ quoteText: newText });
     debounceRegenerateWithNewText();


### PR DESCRIPTION
Preserve newlines in edited text by using `innerText` instead of `textContent` to correctly capture soft line breaks from contenteditable.

The original implementation used `textContent`, which strips newlines from `contenteditable` elements, causing all edited text to appear on a single line after saving. Switching to `innerText` ensures that soft line breaks are maintained, and normalizing `\r\n` to `\n` handles cross-platform newline consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-736db24b-b58c-4207-b14d-a22c3d132dee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-736db24b-b58c-4207-b14d-a22c3d132dee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

