### PR TITLE
Subscription model overhaul

### DIFF
--- a/background.js
+++ b/background.js
@@ -8,44 +8,7 @@ chrome.runtime.onInstalled.addListener(() => {
   });
 });
 
-// Listen for request to fetch user tier (from preview or elsewhere)
-chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-  if (request && request.action === 'fetchUserTier') {
-    try {
-      chrome.storage.local.get(['cognitoIdToken'], async (data) => {
-        const idToken = data && typeof data.cognitoIdToken === 'string' ? data.cognitoIdToken : null;
-        if (!idToken) {
-          sendResponse({ ok: false, error: 'missing_token' });
-          return;
-        }
-        const apiUrl = 'https://quotura.imaginetechverse.com/api/user';
-        try {
-          const resp = await fetch(apiUrl, {
-            method: 'GET',
-            headers: { Authorization: `Bearer ${idToken}`, Accept: 'application/json' },
-            credentials: 'omit',
-            cache: 'no-store',
-          });
-          if (!resp.ok) {
-            sendResponse({ ok: false, status: resp.status });
-            return;
-          }
-          const json = await resp.json();
-          const tier = json && (json.tier === 'pro' ? 'pro' : 'free');
-          const trialStartDate = json && typeof json.trialStartDate === 'string' ? json.trialStartDate : null;
-          chrome.storage.local.set({ userTier: tier, userTrialStartDate: trialStartDate || null }, () => {
-            sendResponse({ ok: true, tier, trialStartDate });
-          });
-        } catch (e) {
-          sendResponse({ ok: false, error: 'network_error' });
-        }
-      });
-    } catch (e) {
-      sendResponse({ ok: false, error: 'unexpected' });
-    }
-    return true; // Keep channel open for async sendResponse
-  }
-});
+// Note: Subscription tiers have been removed; login now unlocks all features.
 
 // Handle context menu clicks
 chrome.contextMenus.onClicked.addListener((info) => {

--- a/popup.js
+++ b/popup.js
@@ -14,15 +14,7 @@
     if (!greetingEl) return;
     if (name && String(name).trim().length > 0) {
       try {
-        const update = (tier) => {
-          const planSuffix = tier ? (tier === 'pro' ? ' — Pro plan' : ' — Free plan') : '';
-          greetingEl.textContent = `Hello ${name}${planSuffix}`;
-        };
-        if (isChromeAvailable()) {
-          chrome.storage.local.get(['userTier'], (d) => update(d && d.userTier));
-        } else {
-          update(localStorage.getItem('userTier'));
-        }
+        greetingEl.textContent = `Hello ${name}`;
       } catch (_) {
         greetingEl.textContent = `Hello ${name}`;
       }
@@ -33,14 +25,12 @@
 
   try {
     if (isChromeAvailable()) {
-      chrome.storage.local.get(['cognitoUserName', 'cognitoSignedIn', 'userTier'], (data) => {
+      chrome.storage.local.get(['cognitoUserName', 'cognitoSignedIn'], (data) => {
         const signedIn = !!(data && data.cognitoSignedIn);
         const name = data && typeof data.cognitoUserName === 'string' ? data.cognitoUserName : '';
         if (signedIn) {
-          const tier = data && typeof data.userTier === 'string' ? data.userTier : null;
           if (name) {
-            const planSuffix = tier ? (tier === 'pro' ? ' — Pro plan' : ' — Free plan') : '';
-            greetingEl.textContent = `Hello ${name}${planSuffix}`;
+            greetingEl.textContent = `Hello ${name}`;
           } else {
             setGreeting('');
           }
@@ -53,13 +43,11 @@
           if (area !== 'local') return;
           const nameChange = changes.cognitoUserName && changes.cognitoUserName.newValue;
           const signedInChange = changes.cognitoSignedIn && changes.cognitoSignedIn.newValue;
-          const tierChange = changes.userTier && changes.userTier.newValue;
-          if (typeof nameChange !== 'undefined' || typeof signedInChange !== 'undefined' || typeof tierChange !== 'undefined') {
-            chrome.storage.local.get(['cognitoUserName', 'cognitoSignedIn', 'userTier'], (d) => {
+          if (typeof nameChange !== 'undefined' || typeof signedInChange !== 'undefined') {
+            chrome.storage.local.get(['cognitoUserName', 'cognitoSignedIn'], (d) => {
               const show = d && d.cognitoSignedIn ? d.cognitoUserName : '';
               if (show) {
-                const planSuffix = d && d.userTier ? (d.userTier === 'pro' ? ' — Pro plan' : ' — Free plan') : '';
-                greetingEl.textContent = `Hello ${show}${planSuffix}`;
+                greetingEl.textContent = `Hello ${show}`;
               } else {
                 setGreeting('');
               }

--- a/preview.html
+++ b/preview.html
@@ -1268,8 +1268,6 @@
         flex-wrap: wrap;
         justify-content: center;
       }
-      /* Upgrade button visual */
-      #upgradeBtn { min-width: 180px; }
 
       /* Personalized greeting above the image, left-aligned with spacing */
       .user-greeting {
@@ -1319,7 +1317,6 @@
         <button id="loginBtn" class="export-btn btn-secondary">🔐 Login</button>
         <button id="signupBtn" class="export-btn btn-primary">📝 Sign up</button>
         <button id="logoutBtn" class="export-btn btn-warning" style="display:none;">🚪 Sign out</button>
-        <button id="upgradeBtn" class="export-btn btn-success" style="display:none;">⭐ Upgrade to Pro</button>
       </div>
     </div>
     
@@ -1358,7 +1355,7 @@
         </button>
         <div id="editPanelLock" class="panel-lock-overlay" aria-hidden="true">
           <span aria-hidden="true">🔒</span>
-          <span>Pro feature</span>
+          <span>Login required</span>
         </div>
       </div>
     </div>
@@ -1400,23 +1397,6 @@
           <div class="auth-popup-text">Opening secure sign-in…</div>
           <div class="auth-popup-actions">
             <button id="authPopupOpenExternalBtn" class="export-btn btn-secondary" style="display:none;">Open sign-in popup</button>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Simple Upgrade to Pro Overlay (placeholder for future upgrade flow) -->
-    <div id="upgradePopupOverlay" class="auth-popup-overlay" aria-hidden="true">
-      <div class="auth-popup-backdrop"></div>
-      <div class="auth-popup-container" role="dialog" aria-modal="true" aria-labelledby="upgradePopupTitle" tabindex="-1">
-        <div class="auth-popup-header">
-          <h3 id="upgradePopupTitle">Upgrade to Pro</h3>
-          <button id="upgradePopupCloseBtn" class="close-btn" aria-label="Close">✕</button>
-        </div>
-        <div class="auth-popup-body">
-          <div class="auth-popup-text">Unlock the editor and remove the watermark with Pro.</div>
-          <div class="auth-popup-actions">
-            <button id="upgradeStartBtn" class="export-btn btn-success">⭐ Upgrade</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Remove the Pro plan and subscription model, making all advanced features available to logged-in users.

The extension is transitioning to a free model, where user login replaces the "Pro" subscription as the gate for full functionality, simplifying the user experience and codebase.

---
<a href="https://cursor.com/background-agent?bcId=bc-3cd55639-0ef3-4635-b597-e4894f4087af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3cd55639-0ef3-4635-b597-e4894f4087af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces Pro/free tier gating with simple sign‑in gating and removes all upgrade/tier logic.
> 
> - Removes user tier fetch/storage and related messaging: deleted background `onMessage` handler for `fetchUserTier`; popup/preview greeting no longer displays plan
> - Consolidates access control to login state: new `userHasFullAccess` and `applyAccessGating(...)` replace tier checks; editor panel lock, inline editor, size/format actions, and watermark removal now require login (not Pro)
> - UI/UX updates: removes Upgrade button and overlay, Pro labels changed to "Login required"; `editHint` updated; `removeWatermarkBtn` label toggles based on sign‑in
> - Ensures watermark for signed‑out users via regeneration path; enables exports consistently when applicable
> - Cleans unused API integration and upgrade flow code; retains Cognito login/signup/logout flows and token handling
> - Misc: `background.js` comment clarifies subscription removal; `preview.html/js` and `popup.js` simplified accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a7f39894379e7e08f8c02f09fd2ec1d359e0087. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->