### PR TITLE
Cognito workflow error

### DIFF
--- a/preview.js
+++ b/preview.js
@@ -159,10 +159,19 @@
     } catch (_) {}
 
   // Centralized Cognito configuration and URL builders
+  function getExtensionRedirectUri() {
+    try {
+      if (window.chrome && chrome.runtime && chrome.runtime.id) {
+        return `chrome-extension://${chrome.runtime.id}/preview.html`;
+      }
+    } catch (_) {}
+    return "chrome-extension://mlkcccmkkcdhalkjnlabofccobpdjbio/preview.html";
+  }
+
   const COGNITO_CONFIG = {
     domain: "https://us-east-1mguj75ffn.auth.us-east-1.amazoncognito.com",
     clientId: "4nak1safpk5ueahr20cr2n4vta",
-    redirectUri: "chrome-extension://dlnlebhcjcjkpbggdloipihaobpmlbld/preview.html",
+    redirectUri: getExtensionRedirectUri(),
     scopes: ["email", "openid"],
   };
 


### PR DESCRIPTION
Update Cognito redirect URI to use runtime extension ID to resolve "Invalid is blocked by chrome" error.

The previous `redirectUri` was hard-coded to a specific Chrome extension ID, which caused the Cognito Hosted UI to redirect to an incorrect or blocked `chrome-extension://` URL, leading to the "Invalid is blocked by chrome" error. This change dynamically retrieves the current extension ID at runtime, falling back to a provided ID if runtime retrieval fails, ensuring the redirect URI is always correct.

---
<a href="https://cursor.com/background-agent?bcId=bc-8567d525-7e93-4acc-b0be-547786e6e5e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8567d525-7e93-4acc-b0be-547786e6e5e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the Cognito Hosted UI redirects to the correct installed extension URL.
> 
> - Add `getExtensionRedirectUri()` to compute `chrome-extension://<runtime-id>/preview.html` with fallback
> - Update `COGNITO_CONFIG.redirectUri` to use the new helper, affecting login/signup/logout/token flows that build URLs from this config
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13768ee824ae0bb0e7f7fae60fe7eeb7b9a66039. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->